### PR TITLE
[Quick fix]: Allow netlify to handle the redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,9 @@
   command = "vite build"
   functions = "netlify/functions"
   publish = "dist"
+
+# handle routing internally.
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
_Netlify documentation has a section, [History Pushstate and Single Page Apps](https://www.netlify.com/docs/redirects/#history-pushstate-and-single-page-apps), which shows you how to redirect to the root of your SPA URL (but doesn’t mention React Router, as it applies to other client-side frameworks/libraries)._